### PR TITLE
Bug fix insufficient fund label logic

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -295,6 +295,6 @@ class Account < ApplicationRecord
   end
 
   def has_sufficient_fund?
-    committed_amt > total_expense
+    committed_amt >= total_expense
   end
 end


### PR DESCRIPTION
# Release Notes

Bug fix: in "billing" module, show insufficient fund label when committed amount greater than or equal to total expense