### PR TITLE
reservation by session in min

### DIFF
--- a/app/controllers/products_common_controller.rb
+++ b/app/controllers/products_common_controller.rb
@@ -39,12 +39,12 @@ class ProductsCommonController < ApplicationController
   def show
     @active_tab = "home"
     product_for_cart = ProductForCart.new(@product)
-    # @add_to_cart = product_for_cart.purchasable_by?(acting_user, session_user) 
+    # @add_to_cart = product_for_cart.purchasable_by?(acting_user, session_user)
 
     @add_to_cart = false
-    if(has_delegated && session[:is_selected_user] == true) 
+    if(has_delegated && session[:is_selected_user] == true)
       @add_to_cart = true
-    else 
+    else
       @add_to_cart = product_for_cart.purchasable_by?(acting_user, session_user)
     end
 
@@ -116,6 +116,7 @@ class ProductsCommonController < ApplicationController
                                                       :user_notes_field_mode, :user_notes_label, :show_details,
                                                       :schedule_id, :control_mechanism, :reserve_interval,
                                                       :min_reserve_mins, :max_reserve_mins, :min_cancel_hours,
+                                                      :session_mins,
                                                       :auto_cancel_mins, :lock_window, :cutoff_hours,
                                                       :problems_resolvable_by_user, :room_no,
                                                       relay_attributes: [:ip, :ip_port, :outlet, :username, :password, :type,

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -28,12 +28,14 @@ class Instrument < Product
   validates :min_reserve_mins,
             :max_reserve_mins,
             :auto_cancel_mins,
+            :session_mins,
             numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
   validates :cutoff_hours, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   validate :minimum_reservation_is_multiple_of_interval,
            :maximum_reservation_is_multiple_of_interval,
-           :max_reservation_not_less_than_min
+           :max_reservation_not_less_than_min,
+           :session_duration_is_multiple_of_interval
 
   # Callbacks
   # --------
@@ -105,6 +107,10 @@ class Instrument < Product
 
   def maximum_reservation_is_multiple_of_interval
     validate_multiple_of_reserve_interval :max_reserve_mins
+  end
+
+  def session_duration_is_multiple_of_interval
+    validate_multiple_of_reserve_interval :session_mins
   end
 
   def validate_multiple_of_reserve_interval(attribute)

--- a/app/support/reservations/validations.rb
+++ b/app/support/reservations/validations.rb
@@ -15,6 +15,7 @@ module Reservations::Validations
              :allowed_in_schedule_rules,
              :satisfies_minimum_length,
              :satisfies_maximum_length,
+             :satisfies_session_length,
              if: ->(r) { r.reserve_start_at && r.reserve_end_at && r.reservation_changed? },
              unless: :admin?
 
@@ -126,6 +127,16 @@ module Reservations::Validations
 
   def satisfies_minimum_length
     errors.add(:base, :too_short, length: product.min_reserve_mins) unless satisfies_minimum_length?
+  end
+
+  def satisfies_session_length?
+    diff = reserve_end_at - reserve_start_at # in seconds
+    return false unless product.session_mins.nil? || product.session_mins == 0 || (diff / 60) % product.session_mins == 0
+    true
+  end
+
+  def satisfies_session_length
+    errors.add(:base, :invalid_session_length, length: product.session_mins) unless satisfies_session_length?
   end
 
   def satisfies_maximum_length?

--- a/app/views/instruments/_instrument_fields.html.haml
+++ b/app/views/instruments/_instrument_fields.html.haml
@@ -60,6 +60,10 @@
     label: text("instruments.instrument_fields.reservation.label.max_reserve"),
     hint: text("instruments.instrument_fields.reservation.instruct.max_reserve")
 
+  = f.input :session_mins,
+    label: text("instruments.instrument_fields.reservation.label.session_reserve"),
+    hint: text("instruments.instrument_fields.reservation.instruct.session_reserve")
+
   = f.input :min_cancel_hours,
     label: text("instruments.instrument_fields.reservation.label.cancel_hours"),
     hint: text("instruments.instrument_fields.reservation.instruct.cancel_hours")

--- a/app/views/instruments/_instrument_manage_fields.html.haml
+++ b/app/views/instruments/_instrument_manage_fields.html.haml
@@ -9,6 +9,7 @@
 = f.input :reserve_interval, value_method: :to_i, label: "Reservation Interval"
 = f.input :min_reserve_mins, value_method: :to_i
 = f.input :max_reserve_mins, default_value: "None"
+= f.input :session_mins, default_value: "None"
 = f.input :min_cancel_hours, value_method: :to_i
 = f.input :auto_cancel_mins, value_method: :to_i
 = f.input :lock_window, value_method: :to_i, default_value: 0

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -111,6 +111,7 @@ en:
               no_schedule_group: You do not have permission to make a reservation at this time
               too_long: The reservation is too long. It cannot be longer than %{length} minutes.
               too_short: The reservation is too short. It must be at least %{length} minutes.
+              invalid_session_length: The reservation must be a mupliter of %{length} minutes.
             reserve_start_at:
               after_cutoff: must be at least %{hours} hours in the future
               in_past: must be in the future
@@ -297,6 +298,7 @@ en:
         min_reserve_mins: Minimum Reservation Minutes
         max_reserve_mins: Maximum Reservation Minutes
         min_cancel_hours: Minimum Cancellation Hours
+        session_mins: Session Duration (Minutes)
         auto_cancel_mins: Automatic Cancellation Minutes
       price_group:
         is_internal: Is Internal?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1310,6 +1310,7 @@ en:
           reserve_interval: "The minutes of an hour on which a reservation is allowed to begin (e.g. if 5 reservations can be scheduled every 5 minutes)"
           min_reserve: "Minimum amount of time for a reservation (optional; must be a multiple of the reservation interval)"
           max_reserve: "Maximum amount of time for a reservation (optional)"
+          session_reserve: "Session duration for a reservation (optional; must be a mulitple of the reservation interval)"
           cancel_hours: "Minimum length of time before a reservation begins that a user may cancel a reservation without invoking the reservation cost"
           auto_cancel: |
             The number of minutes the system will wait before automatically
@@ -1323,6 +1324,7 @@ en:
           reserve_interval: "Interval (minutes)"
           min_reserve: "Minimum (minutes)"
           max_reserve: "Maximum (minutes)"
+          session_reserve: "Session duration (minutes)"
           cancel_hours: "Cancelation Minimum (hours)"
           auto_cancel: "Automatic Cancelation (minutes)"
           lock_window: "Reservation Lock Window (hours)"

--- a/db/migrate/20210714064255_add_session_mins_to_products.rb
+++ b/db/migrate/20210714064255_add_session_mins_to_products.rb
@@ -1,0 +1,5 @@
+class AddSessionMinsToProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :products, :session_mins, :int, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_30_061137) do
+ActiveRecord::Schema.define(version: 2021_07_14_064255) do
 
   create_table "account_facility_joins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "facility_id", null: false
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2021_04_30_061137) do
     t.integer "created_by", null: false
     t.datetime "deleted_at"
     t.integer "deleted_by"
-    t.decimal "allocation_amt", precision: 10, scale: 2
+    t.decimal "allocation_amt", precision: 10, scale: 2, default: 0
     t.index ["account_id"], name: "fk_accounts"
     t.index ["user_id"], name: "index_account_users_on_user_id"
   end
@@ -633,6 +633,7 @@ ActiveRecord::Schema.define(version: 2021_04_30_061137) do
     t.boolean "email_purchasers_on_order_status_changes", default: false, null: false
     t.boolean "problems_resolvable_by_user", default: false, null: false
     t.string "room_no"
+    t.integer "session_mins", default: 0
     t.index ["dashboard_token"], name: "index_products_on_dashboard_token"
     t.index ["facility_account_id"], name: "fk_facility_accounts"
     t.index ["facility_id"], name: "fk_rails_0c9fa1afbe"


### PR DESCRIPTION
# Release Notes

Add session duration to product's reservation restrictions.
Example: if the session duration is 120min, the booking must be a multiplier of 120 mins (120, 240, 360..etc)