### PR TITLE
adjust calendar's slot duration in equipment booking page

### DIFF
--- a/app/assets/javascripts/reservations.js
+++ b/app/assets/javascripts/reservations.js
@@ -1,6 +1,7 @@
 $(document).ready(function() {
   init_datepickers();
   new ReservationCalendar().init($("#calendar"), $(".js--reservationForm"));
+  $('#calendar').fullCalendar('option','slotDuration',slotDuration);
 
   // initialize datepicker
   function init_datepickers() {
@@ -52,4 +53,3 @@ $(document).ready(function() {
   $('.copy_actual_from_reservation a').click(copyReservationTimeIntoActual);
 
 });
-

--- a/app/views/reservations/_js_variables.html.haml
+++ b/app/views/reservations/_js_variables.html.haml
@@ -14,3 +14,4 @@
   var reserveMaximum  = #{@instrument.max_reserve_mins || 0};
   var instrumentOnline = #{@instrument.online?};
   var initialDate = "#{@reservation&.reserve_start_at&.iso8601}";
+  var slotDuration = "00:"+#{@instrument.reserve_interval == 60? 60:30}+":00";


### PR DESCRIPTION
# Release Notes

The booking calendar default duration is 30 min. If the product reserve interval is 60min and the reservation contain half hour, system will prompt error.
Instead of prompting error, will update the booking calendar slot duration to 1 hour if the product reserve interval is 60min.