### PR TITLE
allow order notification send to multiple recipient

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -36,11 +36,11 @@ class Product < ApplicationRecord
   validates :user_notes_field_mode, presence: true, inclusion: Products::UserNoteMode.all
   validates :user_notes_label, length: { maximum: 255 }
 
-  validates :order_notification_recipient,
-            email_format: true,
-            allow_blank: true
+#  validates :order_notification_recipient,
+#            email_format: true,
+#            allow_blank: true
 
-            
+
   # validates(
   #   :account,
   #   presence: true,

--- a/app/views/product_notifications/edit.html.haml
+++ b/app/views/product_notifications/edit.html.haml
@@ -13,7 +13,7 @@
     - if SettingsHelper.feature_on?(:training_requests)
       = f.input :training_request_contacts, as: :string, hint: text("hints.training_request_contacts")
     - key = current_facility.order_notification_recipient.present? ? "hints.order_notification_with_facility" : "hints.order_notification"
-    = f.input :order_notification_recipient, as: :email, hint: text(key, email: current_facility.order_notification_recipient)
+    = f.input :order_notification_recipient, as: :string, hint: text(key, email: current_facility.order_notification_recipient)
     = f.input :cancellation_email_recipients, as: :string, hint: text("hints.cancellation_email_recipients") if @product.is_a?(Instrument)
     = f.input :issue_report_recipients, as: :string, hint: text("hints.issue_report_recipients") if @product.is_a?(Instrument)
 

--- a/config/locales/views/admin/en.product_notifications.yml
+++ b/config/locales/views/admin/en.product_notifications.yml
@@ -10,7 +10,7 @@ en:
         instructions: Leave blank to skip notifications for the event.
         hints:
           order_notification: |
-              This email address will be notified when an order is placed by a user.
+              Comma separated list of email addresses to be notified when an order is placed by a user.
           order_notification_with_facility: |
             !views.product_notifications.edit.hints.order_notification!
             !views.product_notifications.show.hints.already_configured!


### PR DESCRIPTION
# Release Notes

Allow order notification email send to multiple recipient.
