### PR TITLE
show penalty and early end discount

### DIFF
--- a/app/assets/javascripts/app/manage_orders.coffee
+++ b/app/assets/javascripts/app/manage_orders.coffee
@@ -64,21 +64,28 @@ class OrderDetailManagement
   updatePricing: (e) ->
     self = this
     url = @$element.attr('action').replace('/manage', '/pricing')
-    
     @disableSubmit()
 
     $.ajax {
       url: url,
       data: @$element.serialize(),
       type: 'get',
+
       success: (result, status) ->
         # Update price group text
         self.$element.find('.subsidy .help-block').text(result['price_group'])
         subsidy = result['actual_subsidy'] || result['estimated_subsidy']
         self.$element.find('.subsidy input').prop('disabled', subsidy <= 0).css('backgroundColor', '')
 
+        penalty_field = self.$element.find("[name='order_detail[penalty]']")
+        penalty_field.val(result["penalty"])
+
+        early_end_discount_field = self.$element.find("[name='order_detail[early_end_discount]']")
+        early_end_discount_field.val(result["early_end_discount"])
+
         for field in ['cost', 'subsidy', 'total']
           input_field = self.$element.find("[name='order_detail[estimated_#{field}]'],[name='order_detail[actual_#{field}]']")
+
 
           old_val = input_field.val()
           new_val = result["actual_#{field}"] || result["estimated_#{field}"]
@@ -92,10 +99,10 @@ class OrderDetailManagement
     self = this
     $('.cost-table .cost, .cost-table .subsidy, .cost-table .adjust').change ->
       row = $(this).closest('.cost-table')
-      
+
       if !(row.find('.adjust input').val())
         row.find('.adjust input').val(0.00)
-      
+
       total = (row.find('.cost input').val() - row.find('.subsidy input').val()) + parseFloat( row.find('.adjust input').val())
       row.find('.total input').val(total.toFixed(2))
       self.notify_of_update $(row).find('input[name*=total]')

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -22,7 +22,7 @@
     .cost-table {
       clear: both;
 
-      .cost, .subsidy, .total {
+      .cost, .subsidy, .total, .penalty, .early_end_discount {
         width: 1.5in !important;
       }
     }

--- a/app/services/price_policies/time_based_price_calculator.rb
+++ b/app/services/price_policies/time_based_price_calculator.rb
@@ -91,7 +91,7 @@ module PricePolicies
         normal_cost = normal_duration * usage_rate * discount_multiplier
         penalty_cost = penalty_duration * usage_rate * 1.5 * discount_multiplier
 
-        costs = { cost: normal_cost + penalty_cost }
+        costs = { cost: normal_cost + penalty_cost, penalty: penalty_cost }
 
         if costs[:cost] < minimum_cost.to_f
           { cost: minimum_cost, subsidy: minimum_cost_subsidy }
@@ -105,10 +105,10 @@ module PricePolicies
         normal_cost = normal_duration * usage_rate * discount_multiplier
         discount_cost = discount_duration * usage_rate * discount_multiplier * 0.75
 
-        costs = {cost: normal_cost + discount_cost }
+        costs = {cost: normal_cost + discount_cost, early_end_discount: discount_cost }
 
         if costs[:cost] < minimum_cost.to_f
-          { cost: minimum_cost, subsidy: minimum_cost_subsidy }
+          { cost: minimum_cost, subsidy: minimum_cost_subsidy}
         else
           costs.merge(subsidy: normal_duration * usage_subsidy * discount_multiplier)
         end
@@ -117,7 +117,6 @@ module PricePolicies
     end
 
     def cost_and_subsidy_with_penalty(reserve_duration, actual_duration, discount_multiplier)
-
       # actual larger than reserve, charge penalty
       if actual_duration >= reserve_duration
 
@@ -132,7 +131,7 @@ module PricePolicies
         normal_cost = normal_duration * usage_rate * discount_multiplier
         penalty_cost = penalty_duration * usage_rate * 1.5 * discount_multiplier
 
-        costs = { cost: normal_cost + penalty_cost }
+        costs = { cost: normal_cost + penalty_cost, penalty: penalty_cost }
 
         if costs[:cost] < minimum_cost.to_f
           { cost: minimum_cost, subsidy: minimum_cost_subsidy }

--- a/app/support/order_details/price_checker.rb
+++ b/app/support/order_details/price_checker.rb
@@ -18,7 +18,7 @@ class OrderDetails::PriceChecker
 
     fields = [:estimated_cost, :estimated_subsidy, :estimated_total,
               :actual_cost,    :actual_subsidy,    :actual_total,
-              :actual_adjustment]
+              :actual_adjustment, :penalty, :early_end_discount]
 
     results = fields.collect { |f| [f, number_with_precision(@order_detail.send(f), precision: 2)] }
 

--- a/app/views/order_management/order_details/_costs.html.haml
+++ b/app/views/order_management/order_details/_costs.html.haml
@@ -1,7 +1,11 @@
 - f.object.send(:extend, PriceDisplayment)
 - if f.object.actual_cost?
   .cost-table
-    .cost= f.input :actual_cost, as: :currency
+    - if f.object.charge_for_penalty?
+      .penalty= f.input :penalty, as: :currency, disabled:true
+    - if f.object.charge_for_early_end_discount?
+      .early_end_discount= f.input :early_end_discount, as: :currency, disabled:true
+    .cost= f.input :actual_cost, as: :currency, disabled: true
     -#.subsidy= f.input :actual_subsidy, as: :currency, disabled: !f.object.price_policy.try(:has_subsidy?), hint: "#{f.object.price_policy.try(:price_group)}"
     .subsidy= f.hidden_field :actual_subsidy, as: :currency
     .adjust= f.input :actual_adjustment, as: :currency

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -15,12 +15,17 @@
         - @additional_price_policy = @order_detail.product.price_policies.get_additional_price_policy_list
         - @select_additional_price_policy = @order_detail.additional_price_group_id
 
+      - if !@order_detail.policy_charge_for.nil? && @order_detail.reservation.present?
+        .span5
+          = f.input :policy_charge_for, input_html: { value: t("charge_for.#{@order_detail.policy_charge_for}")}, label:"Charge for", as: :readonly
+
       -# .span5.js--additionTypeUpdate
-      .span5.js--pricingUpdate
-        = f.input :additional_price_group_id, collection: AdditionalPriceGroup.select_additional_price_groups(@order_detail.product_id),
-            input_html: { name: "additional_price_policy" },
-            selected: @select_additional_price_policy,
-            include_blank: true
+      - unless @order_detail.additional_price_group_id.nil?
+        .span5.js--pricingUpdate
+          = f.input :additional_price_group_id, collection: AdditionalPriceGroup.select_additional_price_groups(@order_detail.product_id),
+              input_html: { name: "additional_price_policy" },
+              selected: @select_additional_price_policy,
+              include_blank: true
 
       .span5
         - if @order_statuses

--- a/config/locales/en.models.yml
+++ b/config/locales/en.models.yml
@@ -327,6 +327,9 @@ en:
         actual_max_cost: Maximum Cost/Day
         actual_total: Total
         actual_adjustment: Adjustment
+        penalty: Penalty
+        early_end_discount: Early End Discount
+        charge_for: Charge For
         assigned_user: Assigned Staff
         created_by_user: Ordered By
         description: Description

--- a/config/locales/views/admin/en.order_management.yml
+++ b/config/locales/views/admin/en.order_management.yml
@@ -7,3 +7,9 @@ en:
         error: Error while updating order
       remove_from_journal:
         notice: The order has been removed from its journal
+  charge_for:
+    reservation: Reservation
+    usage: Usage
+    overage: Overage
+    overage_penalty: Overage with Penalty
+    overage_penalty_and_end_early_discount: End Early Discount and Overage with Penalty

--- a/db/migrate/20210917074815_add_penalty_to_order_details.rb
+++ b/db/migrate/20210917074815_add_penalty_to_order_details.rb
@@ -1,0 +1,8 @@
+class AddPenaltyToOrderDetails < ActiveRecord::Migration[5.2]
+  def change
+    change_table :order_details do |t|
+      t.decimal :penalty, precision: 13, scale: 2, default: 0, null: false
+      t.decimal :early_end_discount , precision: 13, default: 0, scale: 2, null: false
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

In admin's order detail:
- Show penalty and early end discount fields in the order detail
- Show policy's charging scheme 
- Disable actual cost editing