### PR TITLE
add reconciled checking for ready for statement badge

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -812,7 +812,7 @@ class OrderDetail < ApplicationRecord
   end
 
   def ready_for_statement?
-    reviewed? && statement_id.blank? && Account.config.using_statements?(account.type)
+    reviewed? && statement_id.blank? && Account.config.using_statements?(account.type) && !reconciled?
   end
 
   def ready_for_journal?


### PR DESCRIPTION
# Release Notes

if an order is $0 without statement, hide "Ready for statement" badge in Billing.
