### PR TITLE
Add validation to check addition  item available time

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -234,6 +234,7 @@ class ReservationsController < ApplicationController
     end
 
     @reservation.assign_times_from_params(reservation_params)
+
     with_dropped_params do
       reservation_update_attributes = params.require(:reservation).permit(:note)
       @reservation.assign_attributes(reservation_update_attributes)
@@ -250,6 +251,30 @@ class ReservationsController < ApplicationController
         end
 
         #@order_detail.additional_price_policy_name = params[:additional_price_policy] unless params[:additional_price_policy].nil?
+
+        # Check additional price policy exist in current period    
+        unless params[:additional_price_policy].blank?
+          if @reservation.reserve_start_at < Time.zone.now && params[:additional_price_policy] != @order_detail.additional_price_group_id
+            flash.now[:error] = "The reservation started. You can not change addition item"
+            raise ActiveRecord::Rollback
+          end
+
+          addition_price_policy_list = AdditionalPricePolicy.joins("INNER JOIN additional_price_groups ON additional_price_policies.additional_price_group_id = additional_price_groups.id")
+          .where("additional_price_groups.id = :id", id: params[:additional_price_policy])
+          .joins(:price_policy).where("start_date <= :now AND expire_date > :now", now: @reservation.reserve_start_at).uniq
+
+          is_exist_addition_item = addition_price_policy_list.count > 0 ? true : false
+          
+          unless is_exist_addition_item
+            price_policy_id = AdditionalPricePolicy.joins("INNER JOIN additional_price_groups ON additional_price_policies.additional_price_group_id = additional_price_groups.id")
+            .where("additional_price_groups.id = :id", id: params[:additional_price_policy]).joins(:price_policy).uniq.pluck :price_policy_id
+            start_date = PricePolicy.where("id IN (?)", price_policy_id).where("price_policies.start_date > :now", now: @reservation.reserve_start_at).order("price_policies.start_date ASC").uniq.pluck :start_date 
+            addition_item = AdditionalPriceGroup.find(params[:additional_price_policy])
+            flash.now[:error] = "#{addition_item.name} start on #{format_usa_date(start_date.first)}"
+            raise ActiveRecord::Rollback
+          end
+        end
+
         @order_detail.additional_price_group_id = params[:additional_price_policy] unless params[:additional_price_policy].nil?
         @old_order_detail_estimated_cost = @order_detail.estimated_cost
 

--- a/app/models/additional_price_group.rb
+++ b/app/models/additional_price_group.rb
@@ -13,7 +13,10 @@ class AdditionalPriceGroup < ApplicationRecord
   end
 
   def self.select_additional_price_groups(product_id)
-    where("product_id = :product_id AND deleted_at IS NULL", product_id: product_id)
+    @price_policies = PricePolicy.where("start_date > :now or (start_date <= :now AND expire_date > :now)", now: Time.zone.now).pluck :id
+    # where("product_id = :product_id AND deleted_at IS NULL", product_id: product_id)
+    joins("INNER JOIN additional_price_policies ON additional_price_groups.id = additional_price_policies.additional_price_group_id INNER JOIN price_policies ON price_policies.id = additional_price_policies.price_policy_id ")
+    .where("price_policies.product_id = :product_id AND price_policies.id IN (:price_policy_id)", product_id: product_id, price_policy_id: @price_policies).uniq
   end
 
   def self.delete_price_groups(id)

--- a/app/views/order_management/order_details/_form.html.haml
+++ b/app/views/order_management/order_details/_form.html.haml
@@ -25,7 +25,8 @@
           = f.input :additional_price_group_id, collection: AdditionalPriceGroup.select_additional_price_groups(@order_detail.product_id),
               input_html: { name: "additional_price_policy" },
               selected: @select_additional_price_policy
-
+          - unless @additional_error.nil?
+            %p.additional_error{ :style => "color: red" }= @additional_error
       .span5
         - if @order_statuses
           = f.association :order_status, collection: @order_statuses, label_method: :name_with_level, include_blank: false
@@ -121,3 +122,7 @@
     var reserve_start_date_str = new Date($("#order_detail_reservation_reserve_start_date").val());
     $("#order_detail_reservation_reserve_start_date").val(reserve_start_date_str.getDate() + " " + Date.shortMonths[reserve_start_date_str.getMonth()] + " " + reserve_start_date_str.getFullYear())
   }
+
+  $("#order_detail_additional_price_group_id").change(function() {
+    $(".additional_error").text("");
+  });


### PR DESCRIPTION
# Release Notes

Add reservation validation when ordering instrument with multiple pricing profiles. Check if the selected pricing profile is valid during the reservation period.
