### PR TITLE
Handle reservation overlap

### DIFF
--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -455,6 +455,20 @@ class OrderDetail < ApplicationRecord
     change_status!(OrderStatus.complete)
   end
 
+  def complete_skip_problem!
+
+    @t = Time.current
+
+    @new_t = round_up_15min(@t)
+
+    @end_diff = TimeRange.new(reservation.reserve_end_at, @new_t).duration_mins
+
+    if reservation.card_end_at.nil?
+      reservation.update!(card_end_at: @new_t)
+    end
+    change_status!(OrderStatus.complete)
+  end
+
   def backdate_to_complete!(event_time = Time.zone.now)
     # if we're setting it to compete, automatically set the actuals for a reservation
     if reservation

--- a/app/services/move_to_problem_queue.rb
+++ b/app/services/move_to_problem_queue.rb
@@ -2,8 +2,14 @@
 
 class MoveToProblemQueue
 
+  include DateHelper
+
   def self.move!(order_detail, force: false, user: nil, cause:)
     new(order_detail, force: force, user: user, cause: cause).move!
+  end
+
+  def self.move_skip_problem!(order_detail, force: false, user: nil, cause:)
+    new(order_detail, force: force, user: user, cause: cause).move_skip_problem!
   end
 
   def initialize(order_detail, force: false, user: nil, cause:)
@@ -21,14 +27,37 @@ class MoveToProblemQueue
     @order_detail.time_data.force_completion = @force
     @order_detail.complete!
     LogEvent.log(@order_detail, :problem_queue, @user, metadata: {cause: @cause})
+
     # TODO: Can probably remove this at some point, but it's a safety check for now
     raise "Trying to move Ref. No.#{@order_detail} to problem queue, but it's not a problem" unless @order_detail.problem?
-
     if OrderDetails::ProblemResolutionPolicy.new(@order_detail).user_can_resolve?
       ProblemOrderMailer.notify_user_with_resolution_option(@order_detail).deliver_later
     else
       ProblemOrderMailer.notify_user(@order_detail).deliver_later
     end
+  end
+
+  def move_skip_problem!
+    #when missing actual end time (end by the start of other reservation), set actual_end_at = now and end the reservaton
+    return unless @order_detail.pending?
+
+    @order_detail.time_data.force_completion = @force
+
+    @t = Time.current
+
+    @new_t = round_up_15min(@t)
+
+    @end_diff = TimeRange.new(@order_detail.reservation.reserve_end_at, @new_t).duration_mins
+
+    if @order_detail.reservation.reserve_end_at.to_datetime < @t && @end_diff < 15
+      @order_detail.reservation.update!(card_end_at: @t ,actual_end_at: @order_detail.reservation.reserve_end_at)
+    else
+      @order_detail.reservation.update!(card_end_at: @t ,actual_end_at: @new_t)
+    end
+
+    @order_detail.complete!
+    LogEvent.log(@order_detail, :problem_queue, @user, metadata: {cause: @cause})
+
   end
 
 end


### PR DESCRIPTION
# Release Notes

- Do not allow "Begin reservation" if the instrument is still in use and within reservation period
- When click "Begin reservation" and the instrument is still in use but over reservation period, end the ongoing reservation and fill in the actual end time.
