### PR TITLE
"Send Notification" pagination and review email job

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -5,6 +5,7 @@ module Admin
   class ServicesController < ApplicationController
 
     skip_before_action :verify_authenticity_token
+    http_basic_authenticate_with :name => Settings.basic_authenticate.username, :password => Settings.basic_authenticate.password , only: [:process_daily_delay_email_tasks]
 
     def process_one_minute_tasks
       InstrumentOfflineReservationCanceler.new.cancel!
@@ -16,6 +17,11 @@ module Admin
       self.class.five_minute_tasks.each do |worker|
         worker.new.perform
       end
+      head :ok
+    end
+
+    def process_daily_delay_email_tasks
+      DelayedEmailJobCreator.new.run!
       head :ok
     end
 

--- a/app/controllers/facility_notifications_controller.rb
+++ b/app/controllers/facility_notifications_controller.rb
@@ -33,9 +33,11 @@ class FacilityNotificationsController < ApplicationController
     @search = TransactionSearch::Searcher.billing_search(order_details, @search_form, include_facilities: current_facility.cross_facility?)
     @date_range_field = @search_form.date_params[:field]
     if params[:sort].nil?
-      @order_details = @search.order_details
+      # @order_details = @search.order_details
+      @order_details = @search.order_details.paginate(page: params[:page], per_page: 200)
     else
-      @order_details = @search.order_details.reorder(sort_clause)
+      # @order_details = @search.order_details.reorder(sort_clause)
+      @order_details = @search.order_details.reorder(sort_clause).paginate(page: params[:page], per_page: 200)
     end
 
 
@@ -50,7 +52,7 @@ class FacilityNotificationsController < ApplicationController
       return
     end
 
-    sender = NotificationSender.new(current_facility, params)
+    sender = NotificationSender.new(current_facility, params, true)
 
     if sender.perform
       flash[:notice] = send_notification_success_message(sender)

--- a/app/models/delayed_email_job.rb
+++ b/app/models/delayed_email_job.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DelayedEmailJob < ApplicationRecord
+
+end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -183,6 +183,14 @@ class OrderDetail < ApplicationRecord
       .where(problem: false)
   }
 
+  scope :need_notification_without_reviewed_at, lambda {
+    joins(:product)
+      .where(state: "complete")
+      .with_price_policy
+      .not_disputed
+      .where(problem: false)
+  }
+
   scope :with_insufficient_fund, lambda {
     joins(:product)
       .where(state: "complete")

--- a/app/services/delayed_email_job_creator.rb
+++ b/app/services/delayed_email_job_creator.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class DelayedEmailJobCreator
+  def run!
+    facilities = Facility.all
+    facilities.each do |facility|
+      delay_job_list = get_delay_job_list("OrderDetail", facility)
+      send_email(delay_job_list, facility) if delay_job_list.count > 0      
+    end
+  end
+
+  private
+  
+  def get_delay_job_list(refer_name, facility)
+    DelayedEmailJob.where(sent_at: nil, refer_name: refer_name)
+      .joins("INNER JOIN order_details ON order_details.id = delayed_email_jobs.refer_id")
+      .joins("INNER JOIN orders on orders.id = order_details.order_id")
+      .joins("INNER JOIN facilities on orders.facility_id = facilities.id")
+      .where("facilities.id IN (?)", facility.id)
+  end
+
+  def send_email(delay_job_list, facility)
+    list = Array.new
+    
+    delay_job_list.each do |job|
+      list << job.refer_id.to_s
+    end
+    params = ActionController::Parameters.new({"order_detail_ids" => list})
+    sender = NotificationSender.new(facility, params, false, true)
+    
+    if sender.perform
+      update_delayed_email_job(delay_job_list)
+      sender.order_details.each do |order_detail|
+        LogEvent.log(order_detail, :notify, 0)
+      end
+    end
+  end  
+
+  def update_delayed_email_job(delay_job_list)
+    now = Time.zone.now 
+      ActiveRecord::Base.transaction do
+        begin
+          delay_job_list.each do |email|
+            email.sent_at = now
+            email.save || raise(ActiveRecord::Rollback)
+          end
+        end
+      end
+  end
+end
+  

--- a/app/views/facility_notifications/index.html.haml
+++ b/app/views/facility_notifications/index.html.haml
@@ -27,8 +27,7 @@
             .submit.inline-block
               = submit_tag text("send_notifications", scope: "admin.transaction_search.actions"), class: ["btn", "btn-primary"]
       .row
-        .span12= render "shared/transactions/table_inside", order_details: @order_details
-
+        .span12= render "shared/transactions/table_inside", order_details: @order_details, is_show_total_with_pagination: true
   = render "shared/reconcile_footnote"
 - else
   %p.alert.alert-info= text("facility_notifications.index.no_orders")

--- a/app/views/shared/transactions/_table_inside.html.haml
+++ b/app/views/shared/transactions/_table_inside.html.haml
@@ -2,6 +2,7 @@
 
 - is_sort||="1"
 - is_insufficient_fund||=false
+- is_show_total_with_pagination||=false
 
 %table.table.table-striped.table-hover.dense.old-table
   %thead
@@ -105,9 +106,16 @@
           = order_detail_status_badges(order_detail)
         - if local_assigns[:show_statements]
           %td= link_to "Download", account_statement_path(order_detail.account, order_detail.statement_id, format: :pdf) if order_detail.statement
-  - unless order_details.respond_to? :total_pages
+  - if is_show_total_with_pagination
     %tfoot
       %th.total{ colspan: colspan_for_total, scope: "row" }= t(".total")
       %td.currency= number_to_currency(order_details.map(&:actual_or_estimated_total).compact.sum)
       %td{ colspan: local_assigns[:show_statements] ? 2 : 1 }
+  - unless is_show_total_with_pagination
+    - unless order_details.respond_to? :total_pages
+      %tfoot
+        %th.total{ colspan: colspan_for_total, scope: "row" }= t(".total")
+        %td.currency= number_to_currency(order_details.map(&:actual_or_estimated_total).compact.sum)
+        %td{ colspan: local_assigns[:show_statements] ? 2 : 1 }
+  
 = will_paginate(order_details) if order_details.respond_to? :total_pages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -493,6 +493,7 @@ Rails.application.routes.draw do
     namespace :services do
       post "process_one_minute_tasks"
       post "process_five_minute_tasks"
+      post "process_daily_delay_email_tasks"
     end
   end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,6 +18,10 @@ every 1.minute, roles: [:db] do
   command "curl --silent -X POST #{Rails.application.routes.url_helpers.admin_services_process_one_minute_tasks_url}"
 end
 
+every :day, at: "5:00pm", roles: [:db] do
+  command "curl --silent -X POST #{Rails.application.routes.url_helpers.admin_services_process_daily_delay_email_tasks_url}"
+end
+
 every :day, at: "4:17am", roles: [:db] do
   rake "order_details:remove_merge_orders"
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -189,3 +189,7 @@ uat:
 aes:
   key: ~
   iv: ~
+
+basic_authenticate:
+  username: ~
+  password: ~

--- a/db/migrate/20211104090154_create_delayed_email_jobs.rb
+++ b/db/migrate/20211104090154_create_delayed_email_jobs.rb
@@ -1,0 +1,10 @@
+class CreateDelayedEmailJobs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :delayed_email_jobs do |t|
+      t.integer :refer_id, null: false
+      t.string :refer_name,  null: false, limit: 50
+      t.datetime   :sent_at, null: true
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
# Release Notes

Add pagination to "Send Notification" page, the number of order details per page will be 200.
The review email will send from schedule job instead of sending out immediately.
