### PR TITLE
Rename payment source order label (remove "Ref. No.")

### DIFF
--- a/app/views/facility_account_orders/index.html.haml
+++ b/app/views/facility_account_orders/index.html.haml
@@ -29,9 +29,11 @@
         %tr{class: od.row_class}
           %td
             - if current_ability.can?(:show, order_detail)
-              = link_to od.description, od.show_order_path
+              -# = link_to od.description, od.show_order_path
+              = link_to od.order_number, od.show_order_path
             - else
-              = od.description
+              -# = od.description
+              = od.order_number
 
           %td= od.ordered_at
 


### PR DESCRIPTION
# Release Notes

Remove "Ref. No" from payment source's order list.